### PR TITLE
[release] Replace GitHub token for the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,4 +15,4 @@ jobs:
       - name: Create a new release on the repository
         uses: chaoss/grimoirelab-github-actions/release@master
         with:
-          github-token: ${{ secrets.ACCESS_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The release workflow was using a missing token in the configuration. Use the default `GITHUB_TOKEN` for creating the release on the repository.