### PR TITLE
Upgrade OpenSearch to 2.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM opensearchproject/opensearch:2.7.0
+FROM opensearchproject/opensearch:2.10.0
 
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 LABEL org.opencontainers.image.title="Bitergia Analytics OpenSearch"
@@ -41,4 +41,5 @@ RUN opensearch-keystore create
 RUN opensearch-plugin remove --purge opensearch-neural-search && \
     opensearch-plugin remove --purge opensearch-knn && \
     opensearch-plugin remove --purge opensearch-ml && \
-    opensearch-plugin remove --purge opensearch-reports-scheduler
+    opensearch-plugin remove --purge opensearch-reports-scheduler && \
+    opensearch-plugin remove --purge opensearch-security-analytics

--- a/releases/unreleased/update-to-opensearch-210.yml
+++ b/releases/unreleased/update-to-opensearch-210.yml
@@ -1,0 +1,7 @@
+---
+title: Upgrade to OpenSearch 2.10
+category: dependency
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+  With this release, OpenSearch version has been upgraded to 2.10.


### PR DESCRIPTION
This commit upgrades the base docker image to the 2.10 version.