### PR TITLE
Upgrade OpenSearch to 2.11.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM opensearchproject/opensearch:2.10.0
+FROM opensearchproject/opensearch:2.11.1
 
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 LABEL org.opencontainers.image.title="Bitergia Analytics OpenSearch"

--- a/releases/unreleased/upgrade-to-openserach-2111.yml
+++ b/releases/unreleased/upgrade-to-openserach-2111.yml
@@ -1,0 +1,8 @@
+---
+title: Upgrade to OpenSerach 2.11.1
+category: added
+author: Santiago Dueñas <sduenas@bitergia.com>
+issue: null
+notes: >
+ OpenSearch version has been upgraded to 2.11.1.
+


### PR DESCRIPTION
This commit upgrades the base docker image of OpenSearch to version 2.11.1.