### PR TITLE
Add 'bap_plugins_visibility' role

### DIFF
--- a/releases/unreleased/add-role-to-hide-links-to-plugins.yml
+++ b/releases/unreleased/add-role-to-hide-links-to-plugins.yml
@@ -1,0 +1,8 @@
+---
+title: Add role to hide links to plugins
+category: added
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  Adds the 'bap_plugins_visibility' role, which hides
+  links to plugins for the user on OpenSearch Dashboards.

--- a/security/bap_roles.yml
+++ b/security/bap_roles.yml
@@ -89,3 +89,8 @@ bap_privileged_user_role:
         - "*:.management-beats"
       allowed_actions:
         - "indices_all"
+
+bap_plugins_visibility:
+  reserved: true
+  hidden: false
+  description: "Hides links to plugins on the sidebar menu"


### PR DESCRIPTION
Adds the `bap_plugins_visibility` role to hide links to plugins on the sidebar menu of OpenSearch Dashboards.