### PR TITLE
Upgrade to OpenSearch 2.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (C) Bitergia
 # GPLv3 License
 
-FROM opensearchproject/opensearch:2.11.1
+FROM opensearchproject/opensearch:2.16.0
 
 LABEL maintainer="Santiago Dueñas <sduenas@bitergia.com>"
 LABEL org.opencontainers.image.title="Bitergia Analytics OpenSearch"

--- a/releases/unreleased/upgrade-opensearch-dashboards-version-to-216.yml
+++ b/releases/unreleased/upgrade-opensearch-dashboards-version-to-216.yml
@@ -1,0 +1,8 @@
+---
+title: Upgrade to OpenSearch Dashboards 2.16
+category: dependency
+author: Eva Millán <evamillan@bitergia.com>
+issue: null
+notes: >
+  OpenSearch Dashboards 2.16 fixes an issue with the colors of the 
+  visualizations when there are more than 10 items.


### PR DESCRIPTION
Upgrades the base docker image of OpenSearch to version 2.16.0.