### PR TITLE
Remove unused plugin from Opensearch image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ RUN opensearch-keystore create
 # Remove plugins not supported on this release
 RUN opensearch-plugin remove --purge opensearch-neural-search && \
     opensearch-plugin remove --purge opensearch-knn && \
+    opensearch-plugin remove --purge opensearch-skills && \
     opensearch-plugin remove --purge opensearch-ml && \
     opensearch-plugin remove --purge opensearch-reports-scheduler && \
     opensearch-plugin remove --purge opensearch-security-analytics

--- a/releases/unreleased/opensearch-skills-plugin-removed.yml
+++ b/releases/unreleased/opensearch-skills-plugin-removed.yml
@@ -1,0 +1,8 @@
+---
+title: '`opensearch-skills` plugin removed'
+category: fixed
+author: Jose Javier Merchante <jjmerchante@bitergia.com>
+issue: null
+notes: >
+  Remove `opensearch-skills` plugin, which depends on
+  the `opensearch-ml` plugin that has been removed.


### PR DESCRIPTION
This PR removes the `opensearch-skills` plugin, which depends on the `opensearch-ml` plugin that has been removed.